### PR TITLE
Add option to lookup local device

### DIFF
--- a/public/Get-WarrantyInfo.ps1
+++ b/public/Get-WarrantyInfo.ps1
@@ -3,8 +3,20 @@ function  Get-Warrantyinfo {
     Param(
         [string]$DeviceSerial,
         [String]$client,
-        [String]$vendor
+        [String]$vendor,
+        [switch]$LocalDevice
     )
+    if ($LocalDevice) {
+        $DeviceInfo = Get-CimInstance -ClassName "Win32_Bios" -Property "SerialNumber", "Manufacturer" | Select-Object "Manufacturer", "SerialNumber"
+        if ($DeviceInfo) {
+            if ($DeviceInfo.Manufacturer) {
+                $vendor = $DeviceInfo.Manufacturer
+            }
+            if ($DeviceInfo.SerialNumber) {
+                $DeviceSerial = $DeviceInfo.SerialNumber
+            }
+        }
+    }
     if ($LogActions) { add-content -path $LogFile -Value "Starting lookup for $($DeviceSerial),$($Client)" -force }
     if ($vendor) {
         switch ($vendor) {


### PR DESCRIPTION
This commit adds an option to lookup the local device warranty by
querying "Win32_Bios". This only works on windows AFAIK.

I'm not sure if you would be interested in adding this option but it is here if you'd want it 😄 