### PR TITLE
Corrects the API URL when not provided with it

### DIFF
--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -17,15 +17,6 @@ function  Get-WarrantyCWM {
         'Authorization' = "Basic $Base64Key"
         'Content-Type'  = 'application/json'
     }
-    If (!($CWMAPIURL -match 'api')) {
-        $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
-        $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"
-        $Header = @{
-            'clientId'      = '3613dda6-fa25-49b9-85fb-7aa2b628befa' #This is the warranty script client id. Do not change. 
-            'Authorization' = "Basic $Base64Key"
-            'Content-Type'  = 'application/json'
-        }
-    }
     $i = 0
     If ($ResumeLast) {
         Write-Host "Found previous run results. Starting from last object." -ForegroundColor green

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -17,6 +17,15 @@ function  Get-WarrantyCWM {
         'Authorization' = "Basic $Base64Key"
         'Content-Type'  = 'application/json'
     }
+    If (!($CWMAPIURL -match 'api')) {
+        $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
+        $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"
+        $Header = @{
+            'clientId'      = '3613dda6-fa25-49b9-85fb-7aa2b628befa' #This is the warranty script client id. Do not change. 
+            'Authorization' = "Basic $Base64Key"
+            'Content-Type'  = 'application/json'
+        }
+    }
     $i = 0
     If ($ResumeLast) {
         Write-Host "Found previous run results. Starting from last object." -ForegroundColor green

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -20,6 +20,7 @@ function  Get-WarrantyCWM {
     If (!($CWMAPIURL -match 'api')) {
         $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
         $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"
+        $Base64Key = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$($CWcompanyid)+$($CWMpiKeyPublic):$($CWMpiKeyPrivate)"))
         $Header = @{
             'clientId'      = '3613dda6-fa25-49b9-85fb-7aa2b628befa' #This is the warranty script client id. Do not change. 
             'Authorization' = "Basic $Base64Key"


### PR DESCRIPTION
Pulls the latest API info from /login/companyinfo/connectwise (each new release updates the API URL), and corrects the $CWMAPIURL variable, then redoes the $base64Key and $Header variables.

Example output of Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
where $CWMAPIURL = 'https://na.myconnectwise.net'

CompanyName    : ConnectWise
Codebase       : v2020_4/
VersionCode    : v2020.4
VersionNumber  : v4.6.77997
CompanyID      : CW
IsCloud        : True
SiteUrl        : api-na.myconnectwise.net
AllowedOrigins : {*.connectwisedev.com, *.myconnectwise.net, *.connectwise.net, cw.connectwise.net...}