### PR TITLE
Fix CWManage cloud API URL, device retrieval, and warranty end date format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Devices.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-Devices.json

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -18,8 +18,10 @@ function  Get-WarrantyCWM {
         'Content-Type'  = 'application/json'
     }
     If (!($CWMAPIURL -match 'api')) {
-        $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
-        $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"
+        $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/$cwcompanyid"
+        If ($companyinfo.IsCloud) {
+            $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"
+        }
     }
     $i = 0
     If ($ResumeLast) {

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -29,11 +29,12 @@ function  Get-WarrantyCWM {
         Write-Host "Found previous run results. Starting from last object." -ForegroundColor green
         $Devices = Get-Content 'Devices.json' | ConvertFrom-Json
     } else {
-        do {
-            $Devices += Invoke-RestMethod -Headers $header -Method GET -Uri "$($CWMAPIURL)/company/configurations?pageSize=250&page=$i"
+        $Devices = do {
+            $DeviceList = Invoke-RestMethod -Headers $header -Method GET -Uri "$($CWMAPIURL)/company/configurations?pageSize=250&page=$i"
             $i++
+            $DeviceList
             Write-Host "Retrieved $(250 * $i) configurations" -ForegroundColor Yellow
-        }while ($devices.count % 250 -eq 0 -and $devices.count -ne 0) 
+        }while ($devicelist.count % 250 -eq 0 -and $devicelist.count -ne 0) 
     }
     $warrantyObject = foreach ($device in $Devices) {
         $i++

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -37,6 +37,7 @@ function  Get-WarrantyCWM {
         }while ($devicelist.count % 250 -eq 0 -and $devicelist.count -ne 0) 
     }
     $warrantyObject = foreach ($device in $Devices) {
+        #Write-Host $device.serialnumber
         $i++
         Write-Progress -Activity "Grabbing Warranty information" -Status "Processing $($device.serialnumber). Device $i of $($devices.Count)" -PercentComplete ($i / $Devices.Count * 100)
         $WarState = Get-Warrantyinfo -DeviceSerial $device.serialnumber -client $device.company.name
@@ -44,10 +45,17 @@ function  Get-WarrantyCWM {
 
         if ($script:SyncWithSource -eq $true) {
             if (!$device.warrantyExpirationDate) {
-                $device | Add-Member -NotePropertyName "warrantyExpirationDate" -NotePropertyValue "$($WarState.enddate)T00:00:00Z"
+                if ($warstate.EndDate) {
+                    $EndDate = ($warstate.EndDate).ToString('yyyy-MM-ddT00:00:00Z')
+                    $device | Add-Member -NotePropertyName "warrantyExpirationDate" -NotePropertyValue $EndDate
+                }
             } else { 
-                $device.warrantyExpirationDate = "$($WarState.enddate)T00:00:00Z"
+                if ($warstate.EndDate) {
+                    $EndDate = ($warstate.EndDate).ToString('yyyy-MM-ddT00:00:00Z')
+                    $device.warrantyExpirationDate = $EndDate
+                }
             }
+
             $CWBody = $device | ConvertTo-Json
             switch ($script:OverwriteWarranty) {
                 $true {

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -29,10 +29,9 @@ function  Get-WarrantyCWM {
         Write-Host "Found previous run results. Starting from last object." -ForegroundColor green
         $Devices = Get-Content 'Devices.json' | ConvertFrom-Json
     } else {
-        $Devices = do {
-            $DeviceList = Invoke-RestMethod -Headers $header -Method GET -Uri "$($CWMAPIURL)/company/configurations?pageSize=250&page=$i"
+        do {
+            $Devices += Invoke-RestMethod -Headers $header -Method GET -Uri "$($CWMAPIURL)/company/configurations?pageSize=250&page=$i"
             $i++
-            $DeviceList
             Write-Host "Retrieved $(250 * $i) configurations" -ForegroundColor Yellow
         }while ($devices.count % 250 -eq 0 -and $devices.count -ne 0) 
     }

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -20,12 +20,6 @@ function  Get-WarrantyCWM {
     If (!($CWMAPIURL -match 'api')) {
         $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
         $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"
-        $Base64Key = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$($CWcompanyid)+$($CWMpiKeyPublic):$($CWMpiKeyPrivate)"))
-        $Header = @{
-            'clientId'      = '3613dda6-fa25-49b9-85fb-7aa2b628befa' #This is the warranty script client id. Do not change. 
-            'Authorization' = "Basic $Base64Key"
-            'Content-Type'  = 'application/json'
-        }
     }
     $i = 0
     If ($ResumeLast) {

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -17,15 +17,6 @@ function  Get-WarrantyCWM {
         'Authorization' = "Basic $Base64Key"
         'Content-Type'  = 'application/json'
     }
-    If (!($CWMAPIURL -match 'api')) {
-        $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
-        $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"
-        $Header = @{
-            'clientId'      = '3613dda6-fa25-49b9-85fb-7aa2b628befa' #This is the warranty script client id. Do not change. 
-            'Authorization' = "Basic $Base64Key"
-            'Content-Type'  = 'application/json'
-        }
-    }
     $i = 0
     If ($ResumeLast) {
         Write-Host "Found previous run results. Starting from last object." -ForegroundColor green

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -18,6 +18,7 @@ function  Get-WarrantyCWM {
         'Content-Type'  = 'application/json'
     }
     If (!($CWMAPIURL -match 'api')) {
+        #https://developer.connectwise.com/Best_Practices/Manage_Cloud_URL_Formatting?mt-learningpath=manage
         $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/$cwcompanyid"
         If ($companyinfo.IsCloud) {
             $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -17,6 +17,15 @@ function  Get-WarrantyCWM {
         'Authorization' = "Basic $Base64Key"
         'Content-Type'  = 'application/json'
     }
+    If (!($CWMAPIURL -match 'api')) {
+        $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
+        $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"
+        $Header = @{
+            'clientId'      = '3613dda6-fa25-49b9-85fb-7aa2b628befa' #This is the warranty script client id. Do not change. 
+            'Authorization' = "Basic $Base64Key"
+            'Content-Type'  = 'application/json'
+        }
+    }
     $i = 0
     If ($ResumeLast) {
         Write-Host "Found previous run results. Starting from last object." -ForegroundColor green

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -62,7 +62,6 @@ function  Get-WarrantyCWM {
                     if ($null -ne $warstate.EndDate) {
                         Invoke-RestMethod -Headers $header -Method put -Uri "$($CWMAPIURL)/company/configurations/$($device.id)" -Body $CWBody
                     }
-                     
                 }
                 $false { 
                     if ($null -eq $device.WarrantyExpirationDate -and $null -ne $warstate.EndDate) { 

--- a/private/Get-WarrantyCWM.ps1
+++ b/private/Get-WarrantyCWM.ps1
@@ -20,6 +20,7 @@ function  Get-WarrantyCWM {
     If (!($CWMAPIURL -match 'api')) {
         $companyinfo = Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
         $CWMAPIURL = "https://$($companyinfo.siteurl)/$($companyinfo.Codebase)apis/3.0"
+        $Base64Key = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$($CWcompanyid)+$($CWMpiKeyPublic):$($CWMpiKeyPrivate)"))
         $Header = @{
             'clientId'      = '3613dda6-fa25-49b9-85fb-7aa2b628befa' #This is the warranty script client id. Do not change. 
             'Authorization' = "Basic $Base64Key"


### PR DESCRIPTION
Pulls the latest API info from /login/companyinfo/connectwise (each new release updates the API URL), and corrects the $CWMAPIURL variable.

Example output of Invoke-RestMethod -Headers $header -Method GET -Uri "$CWMAPIURL/login/companyinfo/connectwise"
where $CWMAPIURL = 'https://na.myconnectwise.net'

CompanyName : ConnectWise
Codebase : v2020_4/
VersionCode : v2020.4
VersionNumber : v4.6.77997
CompanyID : CW
IsCloud : True
SiteUrl : api-na.myconnectwise.net
AllowedOrigins : {*.connectwisedev.com, *.myconnectwise.net, *.connectwise.net, cw.connectwise.net...}