### PR TITLE
Blacklist of Dell Service codes

### DIFF
--- a/private/Get-DellWarranty.ps1
+++ b/private/Get-DellWarranty.ps1
@@ -1,3 +1,6 @@
+# This is a list of Service Level Codes that may be returned by the API that are not related to hardware warranties
+$SLCBlacklist = @("D", "DL", "PJ", "PR");
+
 function get-DellWarranty([Parameter(Mandatory = $true)]$SourceDevice, $Client) {
     if ($null -eq $Script:DellClientID) {
         write-error "Cannot continue: Dell API information not found. Please run Set-WarrantyAPIKeys before checking Dell Warranty information."
@@ -27,14 +30,15 @@ function get-DellWarranty([Parameter(Mandatory = $true)]$SourceDevice, $Client) 
     $headersReq = @{ "Authorization" = "Bearer $Script:Token" }
     $ReqBody = @{ servicetags = $SourceDevice }
     $WarReq = Invoke-RestMethod -Uri "https://apigtwb2c.us.dell.com/PROD/sbil/eapi/v5/asset-entitlements" -Headers $headersReq -Body $ReqBody -Method Get -ContentType "application/json"
-    $warlatest = $warreq.entitlements.enddate | sort-object | select-object -last 1 
+    $warEntitlements = $warreq.entitlements | Where-Object { $_.serviceLevelCode -notin $SLCBlacklist }
+    $warlatest = $warEntitlements.enddate | sort-object | select-object -last 1 
     $WarrantyState = if ($warlatest -le $today) { "Expired" } else { "OK" }
     if ($warlatest) {
-        $StartDate = $warreq.entitlements.startdate | ForEach-Object { [DateTime]$_ } | sort-object -Descending | select-object -last 1
-        $EndDate = $warreq.entitlements.enddate | ForEach-Object { [DateTime]$_ } | sort-object -Descending | select-object -first 1
+        $StartDate = $warEntitlements.startdate | ForEach-Object { [DateTime]$_ } | sort-object -Descending | select-object -last 1
+        $EndDate = $warEntitlements.enddate | ForEach-Object { [DateTime]$_ } | sort-object -Descending | select-object -first 1
         $WarObj = [PSCustomObject]@{
             'Serial'                = $SourceDevice
-            'Warranty Product name' = $warreq.entitlements.serviceleveldescription -join "`n"
+            'Warranty Product name' = ($warEntitlements.serviceleveldescription | Sort-Object -Unique) -join "`n"
             'StartDate'             = $StartDate
             'EndDate'               = $EndDate
             'Warranty Status'       = $WarrantyState


### PR DESCRIPTION
This commit adds a blacklist of Dell Service Codes that are not warranty related. It will filter out any entitlements returned by the API that are in this blacklist. 

See PR #48 for more info.