### PR TITLE
HP Error Convert Date

### DIFF
--- a/private/Get-HPWarranty.ps1
+++ b/private/Get-HPWarranty.ps1
@@ -7,7 +7,7 @@ function get-HPWarranty([Parameter(Mandatory = $true)]$SourceDevice, $Client) {
     }
 
 
-    if ($HPreq) {
+    if ($HPreq.StartDate) {
         $today = Get-Date
         $WarrantyState = if ([DateTime]$HPReq.endDate -le $today) { "Expired" } else { "OK" }
         $WarObj = [PSCustomObject]@{


### PR DESCRIPTION
Hi Kelvin, upon using a valid HP serial which probably HP does not source warranty information for the HP api returns the data with serial number and all the other fields with $null. Then when the function tries to convert start date (because it doesnt exists) it throws an error
```
Cannot convert null to type "System.DateTime".
At C:\Program Files\WindowsPowerShell\Modules\PSWarranty\1.7.1\private\Get-HPWarranty.ps1:12 char:30
+ ...      $WarrantyState = if ([DateTime]$HPReq.endDate -le $today) { "Exp ...
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [], RuntimeException
    + FullyQualifiedErrorId : nullToObjectInvalidCast
 
Cannot convert null to type "System.DateTime".
At C:\Program Files\WindowsPowerShell\Modules\PSWarranty\1.7.1\private\Get-HPWarranty.ps1:13 char:9
+         $WarObj = [PSCustomObject]@{
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [], RuntimeException
    + FullyQualifiedErrorId : nullToObjectInvalidCast
```

I've changed the function to only try to convert the dates if startdate is not empty. 