### PR TITLE
Remove Write-Host as it can't be removed from output easily

### DIFF
--- a/public/Set-WarrantyAPIKeys.ps1
+++ b/public/Set-WarrantyAPIKeys.ps1
@@ -6,7 +6,7 @@ function Set-WarrantyAPIKeys {
         [Parameter(ParameterSetName = 'Dell', Mandatory = $false)]
         [String]$DellClientSecret
     )
-    write-host "Setting Dell Warranty API Keys" -ForegroundColor Green
+    #write-host "Setting Dell Warranty API Keys" -ForegroundColor Green
     $script:DellClientID = $DellClientID
     $script:DellClientSecret = $DellClientSecret
 }


### PR DESCRIPTION
In Atera, I use output value to update a field, but if you already output data, it messes outputed value. 

The only solution was to redefine Write-Host
`function Write-Host { }`
then put it back:
`Remove-Item function:\Write-Host`